### PR TITLE
Fix: Update PostCSS config to use @tailwindcss/postcss

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.4",
-    "tailwindcss": "^4.1.8"
+    "tailwindcss": "^4.1.8",
+    "@tailwindcss/postcss": "^4.1.8"
   }
 }

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }


### PR DESCRIPTION
The Tailwind CSS PostCSS plugin was moved to a separate package, `@tailwindcss/postcss`. This commit updates the frontend build configuration to use the new package.

Changes:
- Added `@tailwindcss/postcss` to `devDependencies` in `frontend/package.json`.
- Updated `frontend/postcss.config.js` to load `@tailwindcss/postcss` instead of `tailwindcss` directly as a PostCSS plugin.