### PR TITLE
Fix: Update type hints for Python 3.9 compatibility

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from sqlalchemy import Column, Integer, String, create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from pydantic import BaseModel, EmailStr
@@ -18,15 +19,15 @@ class User(Base):
 class UserCreate(BaseModel):
     name: str
     email: EmailStr
-    organisation: str | None = None
-    position: str | None = None
+    organisation: Optional[str] = None
+    position: Optional[str] = None
 
 class UserResponse(BaseModel):
     userID: int
     name: str
     email: EmailStr
-    organisation: str | None = None
-    position: str | None = None
+    organisation: Optional[str] = None
+    position: Optional[str] = None
 
     class Config:
         orm_mode = True # Compatibility with SQLAlchemy models


### PR DESCRIPTION
I replaced the use of `|` operator for optional types (e.g., `str | None`) with `Optional[str]` from the `typing` module in `backend/app/models.py`.

This change addresses a `TypeError` occurring because the `|` operator for type hints was introduced in Python 3.10, and your application is running on Python 3.9.

The following models were updated:
- UserCreate
- UserResponse