### PR TITLE
Fix: Add pydantic[email] to requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ tiktoken
 langchain-community
 httpx
 langchain-experimental
+pydantic[email]


### PR DESCRIPTION
I've added `pydantic[email]` to `backend/requirements.txt` to ensure the `email-validator` dependency is installed.

This resolves an `ImportError` that occurred because Pydantic's email validation feature requires this additional package.