### PR TITLE
I've made a fix: Comment out unused SqliteSaver import.

### DIFF
--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -12,7 +12,7 @@ from langchain_core.messages import BaseMessage, HumanMessage, AIMessage, ToolMe
 from langchain_core.runnables import RunnablePassthrough, RunnableLambda
 from langchain_core.tools import tool
 from langgraph.graph import StateGraph, END
-from langgraph.checkpoint.sqlite import SqliteSaver # For more robust history/state if needed later
+# from langgraph.checkpoint.sqlite import SqliteSaver # For more robust history/state if needed later
 from langchain_experimental.pydantic_v1 import BaseModel, Field # Use v1 for Langchain compatibility
 
 from ..core.config import settings


### PR DESCRIPTION
I commented out the import statement for `langgraph.checkpoint.sqlite.SqliteSaver` in `backend/app/services/chat_service.py`.

This import was causing a `ModuleNotFoundError` when the application started. The actual usage of `SqliteSaver` for checkpointing in the graph compilation was already commented out. This change prevents the import of an unused module that was not being found in the current environment.

If you decide to enable SQLite checkpointing in the future, the import will need to be uncommented, and you should verify that the `langgraph` installation includes the necessary components for sqlite support (e.g., by installing `langgraph[sqlite]`).