### PR TITLE
I've added CORS middleware to the FastAPI application in `backend/app…

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, Depends, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 from typing import List, Dict, Optional
 
@@ -42,6 +43,15 @@ async def lifespan(app: FastAPI):
     print("Application shutdown...")
 
 app = FastAPI(lifespan=lifespan)
+
+# Add CORS middleware
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # Allows all origins
+    allow_credentials=True,
+    allow_methods=["*"],  # Allows all methods
+    allow_headers=["*"],  # Allows all headers
+)
 
 @app.post("/chat/start", response_model=models.UserResponse)
 def start_chat(user_data: models.UserCreate): # Removed db: Session = Depends(get_db)


### PR DESCRIPTION
…/main.py`. This should fix an issue where POST requests to `/chat/start` and `/chat` were failing with 404 errors.

It seems the browser's Same-Origin Policy (SOP) was preventing cross-origin POST requests from your frontend (e.g., `http://localhost:3000`) to the backend (e.g., `http://localhost:8000`) because the backend wasn't sending the right CORS headers.

I've configured the middleware to allow:
- All origins (`allow_origins=["*"]`)
- All HTTP methods (`allow_methods=["*"]`)
- All headers (`allow_headers=["*"]`)
- Credentials (`allow_credentials=True`)

This should allow your frontend to make POST requests to the backend successfully.