### PR TITLE
Revert to Gemini LLM and implement frontend user IDs

### DIFF
--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -5,9 +5,9 @@ from operator import itemgetter
 
 from langchain_community.document_loaders import PyPDFLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter
-from langchain_anthropic import ChatAnthropic # Added ChatAnthropic
-from langchain_openai import OpenAIEmbeddings
+from langchain_google_genai import GoogleGenerativeAIEmbeddings, ChatGoogleGenerativeAI # Reverted to Google
 from langchain_community.vectorstores import FAISS
+# Removed OpenAIEmbeddings and ChatAnthropic imports as they are no longer used
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_core.messages import BaseMessage, HumanMessage, AIMessage, ToolMessage, SystemMessage
 from langchain_core.runnables import RunnablePassthrough, RunnableLambda
@@ -55,10 +55,10 @@ def load_and_process_pdfs():
         return None
 
     try:
-        print(f"Initializing OpenAIEmbeddings with API key...") # Updated print
-        embeddings = OpenAIEmbeddings(model="text-embedding-ada-002", openai_api_key=settings.OPENAI_API_KEY) # Changed to OpenAIEmbeddings
+        print(f"Initializing GoogleGenerativeAIEmbeddings with API key: {settings.GOOGLE_API_KEY[:15]}...") # Reverted
+        embeddings = GoogleGenerativeAIEmbeddings(model="models/embedding-001", google_api_key=settings.GOOGLE_API_KEY) # Reverted
         vector_store_instance = FAISS.from_documents(documents, embeddings)
-        print("FAISS vector store created with OpenAI embeddings.") # Updated print
+        print("FAISS vector store created with Google embeddings.") # Reverted
     except Exception as e:
         print(f"Error during embedding or FAISS creation: {e}")
         vector_store_instance = None
@@ -165,16 +165,17 @@ def llm_call_node(state: GraphState):
     ])
 
     # Initialize LLM with tools
-    # Ensure ANTHROPIC_API_KEY is available
-    if not settings.ANTHROPIC_API_KEY or settings.ANTHROPIC_API_KEY == "your_anthropic_api_key_here": # Updated for Anthropic
-        print("ERROR: ANTHROPIC_API_KEY not configured. LLM call will fail.") # Updated for Anthropic
+    # Ensure GOOGLE_API_KEY is available
+    if not settings.GOOGLE_API_KEY or settings.GOOGLE_API_KEY == "your_google_api_key_here": # Reverted
+        print("ERROR: GOOGLE_API_KEY not configured. LLM call will fail.") # Reverted
         # Return a message indicating this failure.
         ai_response = AIMessage(content="I cannot process your request right now as my connection to the language model is not configured (API key missing). Please contact support.")
         return {"messages": state["messages"] + [ai_response]}
 
-    llm = ChatAnthropic( # Changed to ChatAnthropic
-        model="claude-3-haiku-20240307", # Changed model
-        anthropic_api_key=settings.ANTHROPIC_API_KEY # Changed API key
+    llm = ChatGoogleGenerativeAI( # Reverted to ChatGoogleGenerativeAI
+        model="gemini-pro", # Reverted model
+        google_api_key=settings.GOOGLE_API_KEY, # Reverted API key
+        convert_system_message_to_human=True # Reinstated
     )
     llm_with_tools = llm.bind_tools([fetch_website_content], tool_choice=None) # None means LLM decides
 
@@ -310,13 +311,9 @@ chat_service_instance: Optional[ChatService] = None
 
 def initialize_chat_service():
     global chat_service_instance
-    # Updated to check for ANTHROPIC_API_KEY as it's now the primary LLM
-    if not settings.ANTHROPIC_API_KEY or settings.ANTHROPIC_API_KEY == "your_anthropic_api_key_here":
-        print("WARNING: ANTHROPIC_API_KEY is not set. Chat service LLM calls will likely fail.")
-        # We can still initialize the service, but it will return errors.
-    elif not settings.GOOGLE_API_KEY or settings.GOOGLE_API_KEY == "your_google_api_key_here":
-        # This is a secondary warning, as Google API might be used by other parts or future features
-        print("WARNING: GOOGLE_API_KEY is not set. Some functionalities might be affected if they rely on Google services directly.")
+    # Reverted to check for GOOGLE_API_KEY as it's now the primary LLM
+    if not settings.GOOGLE_API_KEY or settings.GOOGLE_API_KEY == "your_google_api_key_here":
+        print("WARNING: GOOGLE_API_KEY is not set. Chat service LLM calls will fail.")
         # We can still initialize the service, but it will return errors.
 
     # Ensure vector store is loaded before ChatService initialization if it depends on it

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "react-router-dom": "^7.6.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
+    "uuid": "^9.0.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
@@ -48,6 +49,7 @@
   },
   "devDependencies": {
     "@types/react-router-dom": "^5.3.3",
+    "@types/uuid": "^9.0.0",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.4",
     "tailwindcss": "^3.4.17"


### PR DESCRIPTION
This commit includes two main changes:

1. Backend: Reverted the LLM and embedding provider from Anthropic/OpenAI back to Google Gemini.
    - `ChatGoogleGenerativeAI` (gemini-pro) is now used for chat.
    - `GoogleGenerativeAIEmbeddings` is used for PDF processing.
    - API key configurations and checks now primarily use `GOOGLE_API_KEY`.

2. Frontend: Implemented unique user ID generation.
    - Added `uuid` package to `frontend/package.json`. (Requires `npm install` or `yarn install` in the frontend directory).
    - `ChatPage.tsx` now generates a unique `userId` using `uuidv4()`, stores it in `localStorage` for persistence across sessions, and sends this `userId` in API requests to the backend instead of the previously hardcoded `1`.

These changes address your feedback to switch back to Gemini and to enable distinct user identification from the frontend.